### PR TITLE
log phpunit issues

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,10 @@
      stopOnIncomplete="false"
      stopOnSkipped="false"
      bootstrap="vendor/autoload.php"
+  displayDetailsOnTestsThatTriggerDeprecations="true"
+  displayDetailsOnTestsThatTriggerNotices="true"
+  displayDetailsOnTestsThatTriggerWarnings="true"
+  displayDetailsOnTestsThatTriggerErrors="true"
 >
     <testsuites>
         <testsuite name="AllTests">


### PR DESCRIPTION
```
There was 1 PHP warning:

1) SimpleTest::testCorrectBuilding with data set #3
* foreach() argument must be of type array|object, string given

* foreach() argument must be of type array|object, string given

K:\dev\github\php-array-table\tests\SimpleTest.php:12

OK, but some tests have issues!
Tests: 11, Assertions: 11, Warnings: 1.
```