### PR TITLE
Add support for null values

### DIFF
--- a/src/ArrayToTextTable.php
+++ b/src/ArrayToTextTable.php
@@ -129,9 +129,14 @@ class ArrayToTextTable
 
     protected function validateData()
     {
-        foreach ($this->data as $row) {
-            foreach ($row as $column) {
+        foreach ($this->data as &$row) {
+            foreach ($row as &$column) {
                 if (!is_scalar($column)) {
+                    if (is_null($column)) {
+                        $column = 'NULL';
+                        continue;
+                    }
+
                     throw new ArrayToTextTableException(
                         'Tried to render invalid data: ' . print_r($column, 1) . '. Only scalars allowed'
                     );

--- a/tests/SimpleTest.php
+++ b/tests/SimpleTest.php
@@ -105,6 +105,21 @@ class SimpleTest extends TestCase
                     '| 2  | Артем Малеев  | Тест кириллических символов 2 |' . PHP_EOL .
                     '+----+---------------+-------------------------------+',
             ],
+            [
+                'data' => [
+                    ['test' => 1],
+                    ['test' => -1],
+                    ['test' => null],
+                ],
+                'expected' =>
+                    '+------+' . PHP_EOL .
+                    '| test |' . PHP_EOL .
+                    '+------+' . PHP_EOL .
+                    '| 1    |' . PHP_EOL .
+                    '| -1   |' . PHP_EOL .
+                    '| NULL |' . PHP_EOL .
+                    '+------+',
+            ],
         ];
     }
 


### PR DESCRIPTION
Null values in table throw exception

    dekor\ArrayToTextTableException: Tried to render invalid data: . Only scalars allowed in /srv/en/html/vendor/dekor/php-array-table/src/ArrayToTextTable.php:135
    Stack trace:
    #0 /srv/en/html/vendor/dekor/php-array-table/src/ArrayToTextTable.php(111): dekor\ArrayToTextTable->validateData()
    #1 /srv/en/html/api/stats/src/Command.php(528): dekor\ArrayToTextTable->render()
    #2 /srv/en/html/api/stats/index.php(154): CopyTrans\Stats\Command->analyzeA1()
    #3 [internal function]: CopyTrans\Stats\{closure}()
    #4 /srv/en/html/vendor/clue/commander/src/Route.php(78): call_user_func()
    #5 /srv/en/html/vendor/clue/commander/src/Router.php(179): Clue\Commander\Route->__invoke()
    #6 /srv/en/html/vendor/clue/commander/src/Router.php(152): Clue\Commander\Router->handleArgs()
    #7 /srv/en/html/api/stats/index.php(248): Clue\Commander\Router->handleArgv()
    #8 {main}

Here's the table:

      2023-02-03 08:25:45 	62095207 	ENGG51U5C616QSTYI8 	        user@domain.net
      2023-02-03 08:24:53 	62095136 	ENCK3GJO4QWHC7L6TY 	NULL	
      2023-02-01 14:26:47 	61925526 	ENGG51U5C616QSTYI8 	        NULL	
      2023-02-01 14:24:08 	61925187 	ENCK3GJO4QWHC7L6TY 	NULL
      
This pull request fixes it by replacing `null` by 'NULL' string.