### PR TITLE
Fix array to string conversion warning

### DIFF
--- a/src/ArrayToTextTable.php
+++ b/src/ArrayToTextTable.php
@@ -130,6 +130,10 @@ class ArrayToTextTable
     protected function validateData()
     {
         foreach ($this->data as &$row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
             foreach ($row as &$column) {
                 if (!is_scalar($column)) {
                     if (is_null($column)) {
@@ -155,6 +159,10 @@ class ArrayToTextTable
     protected function applyBeforeFormatters()
     {
         foreach ($this->data as $key => $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
             foreach ($row as $columnKey => $value) {
                 foreach ($this->columnFormatters as $formatter) {
                     $this->data[$key][$columnKey] = $formatter->process($columnKey, $value, true);


### PR DESCRIPTION
Without the fix:

```txt
PHPUnit 10.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.11 with Xdebug 3.4.0beta1
Configuration: K:\dev\github\php-array-table\phpunit.xml

D........W..                                                      12 / 12 (100%)

Time: 00:00.526, Memory: 12.00 MB

1 test triggered 2 PHP warnings:

1) K:\dev\github\php-array-table\src\ArrayToTextTable.php:133
foreach() argument must be of type array|object, string given

Triggered by:

* SimpleTest::testCorrectBuilding#3
  K:\dev\github\php-array-table\tests\SimpleTest.php:20

2) K:\dev\github\php-array-table\src\ArrayToTextTable.php:158
foreach() argument must be of type array|object, string given

Triggered by:

* SimpleTest::testCorrectBuilding#3
  K:\dev\github\php-array-table\tests\SimpleTest.php:20

OK, but there were issues!
Tests: 12, Assertions: 12, Warnings: 2, PHPUnit Deprecations: 9.

Generating code coverage report in HTML format ... done [00:00.778]
```