### PR TITLE
Run tests under php 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [5.6, 8.2]
+        php-version: [5.6, 8.4]
 
         dependencies:
           - "highest"


### PR DESCRIPTION
Automated tests now run with php 8.4 instead of php 8.2.