### PR TITLE
Add support for phpunit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5|^6|^7|^8|^9|^10",
+        "phpunit/phpunit": "^5|^6|^7|^8|^9|^10|^11",
         "friendsofphp/php-cs-fixer": "^2|^3"
     },
     "autoload": {

--- a/tests/AlignFormatterTest.php
+++ b/tests/AlignFormatterTest.php
@@ -16,14 +16,14 @@ class AlignFormatterTest extends TestCase
      * @dataProvider getCases
      *
      * @param mixed $data
-     * @param mixed $expectResult
+     * @param mixed $expected
      */
-    public function testCorrectBuilding($data, $expectResult)
+    public function testCorrectBuilding($data, $expected)
     {
         $builder = new ArrayToTextTable($data);
         $builder->applyFormatter(new AlignFormatter(['center' => 'center', 'right' => 'right']));
 
-        $this->assertEquals($expectResult, $builder->render());
+        $this->assertEquals($expected, $builder->render());
     }
 
     public static function getCases()

--- a/tests/ColorTest.php
+++ b/tests/ColorTest.php
@@ -17,9 +17,9 @@ class ColorTest extends TestCase
      * @dataProvider getCases
      *
      * @param mixed $data
-     * @param mixed $expectResult
+     * @param mixed $expected
      */
-    public function testCorrectBuilding($data, $expectResult)
+    public function testCorrectBuilding($data, $expected)
     {
         $builder = new ArrayToTextTable($data);
         $builder->applyFormatter(new ColorFormatter([
@@ -28,7 +28,7 @@ class ColorTest extends TestCase
             }
         ]));
 
-        $this->assertEquals($expectResult, $builder->render());
+        $this->assertEquals($expected, $builder->render());
     }
 
     public static function getCases()

--- a/tests/CombinedAlignSprintfFormatterTest.php
+++ b/tests/CombinedAlignSprintfFormatterTest.php
@@ -17,15 +17,15 @@ class CombinedAlignSprintfFormatterTest extends TestCase
      * @dataProvider getCases
      *
      * @param mixed $data
-     * @param mixed $expectResult
+     * @param mixed $expected
      */
-    public function testCorrectBuilding($data, $expectResult)
+    public function testCorrectBuilding($data, $expected)
     {
         $builder = new ArrayToTextTable($data);
         $builder->applyFormatter(new AlignFormatter(['center' => 'center', 'right' => 'right']));
         $builder->applyFormatter(new SprintfFormatter(['right' => '%01.3f']));
 
-        $this->assertEquals($expectResult, $builder->render());
+        $this->assertEquals($expected, $builder->render());
     }
 
     public static function getCases()

--- a/tests/SimpleTest.php
+++ b/tests/SimpleTest.php
@@ -15,13 +15,13 @@ class SimpleTest extends TestCase
      * @dataProvider getCases
      *
      * @param mixed $data
-     * @param mixed $expectResult
+     * @param mixed $expected
      */
-    public function testCorrectBuilding($data, $expectResult)
+    public function testCorrectBuilding($data, $expected)
     {
         $builder = new ArrayToTextTable($data);
 
-        $this->assertEquals($expectResult, $builder->render());
+        $this->assertEquals($expected, $builder->render());
     }
 
     public static function getCases()


### PR DESCRIPTION
`$expectedResult` must be renamed to `$expected` as phpunit 11 uses the name of the keys from the data provider array.  